### PR TITLE
fix: unhandle error

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Use the `ad-slot` property to specify your google adsense ad slot value (specifi
 | `ad-slot` | String | Google Adsense adslot. **This prop is required when not in test mode**. Refer to your AdSense account for ad-slot values.
 | `ad-format` | String | Defaults to `'auto'`. Refer to the adsense docs for other options
 | `ad-style` | Object | Styles to apply to the rendered `<ins>` element. Default: `{ display: 'block' }`. Refer to VueJS [style binding docs](https://vuejs.org/v2/guide/class-and-style.html#Object-Syntax-1) for the Object format.
+| `ad-layout` | String | Optional. Refer to the adsense docs
+| `ad-layout-key` | String | Optional. Refer to the adsense docs
 | `page-url` | String | Optional.  Set a reference page URL (of similar content) if the ad is on a page that requires authentication. When set, this prop must be a fully qualified URL (inclcuding protocol and hostname).
 | `include-query` | Boolean | Override global option `includeQuery` on a per ad basis. Ensure all ads on a page have the same setting.
 | `analytics-uacct` | String | Google Analytics Account ID (if linking analytics with AdSense, i.e. `UA-#######-#`). Defaults to the value specified in the plugin option `analyticsUacct`.

--- a/lib/plugin.template.js
+++ b/lib/plugin.template.js
@@ -13,6 +13,8 @@ const adsbygoogle = {
           'data-ad-slot': this.adSlot || null,
           'data-ad-format': this.adFormat,
           'data-ad-region': this.show ? this.adRegion() : null,
+          'data-ad-layout': this.adLayout || null,
+          'data-ad-layout-key': this.adLayoutKey || null,
           'data-page-url': this.pageUrl ? this.pageUrl : null,
           'data-analytics-uacct': this.analyticsUacct ? this.analyticsUacct : null,
           'data-analytics-domain-name': this.analyticsDomainName ? this.analyticsDomainName : null,
@@ -37,6 +39,12 @@ const adsbygoogle = {
     adFormat: {
       type: String,
       default: 'auto'
+    },
+    adLayout: {
+      type: String
+    },
+    adLayoutKey: {
+      type: String
     },
     adStyle: {
       type: Object,

--- a/lib/plugin.template.js
+++ b/lib/plugin.template.js
@@ -107,8 +107,12 @@ const adsbygoogle = {
     showAd () {
       this.show = true
       this.$nextTick(() => {
-        // Once ad container (<ins>) DOM has (re-)rendered, requesst a new advert
-        (window.adsbygoogle = window.adsbygoogle || []).push({})
+        try {
+          // Once ad container (<ins>) DOM has (re-)rendered, requesst a new advert
+          (window.adsbygoogle = window.adsbygoogle || []).push({})
+        } catch (error) {
+          console.error(error)
+        }
       })
     }
   }


### PR DESCRIPTION
Try/Catch was added to handle errors. Previously when error
happened the whole application stopped working.

For example ```adsbygoogle.push() error: Fluid responsive ads must be at least 250px wide``` blow whole nuxt application.