### PR TITLE
feat: Add option to prevent top anchor/PageLevel ads

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,10 @@ added to the `<head>` section of your pages.
 ## Configuration options
 
 | Option | type |  description
-| -------- | ---- | -----------
+| ------ | ---- | -----------
 | `id` | String | Your Google Adsense Publihser client ID (i.e. `ca-pub-#########`). **Required** when not in test mode.
 | `pageLevelAds` | Boolean | Enable Adsense Page Level Ads. Default is `false`. Refer to the AdSense docs for details.
+| `preventTopAnchorAds` | Boolean | Only allow Page Level Ads to be displayed on bottom of page. Has no effect is `pageLevelAds` is not `true`
 | `tag` | String | AdSense component tag name. Defaults to `adsbygoogle`.
 | `includeQuery` | Boolean | When `false`, only `$route.path` is checked for changes. If set to `true` `$route.query` will also be taken into account. The default is `false`.
 | `analyticsUacct` | String | Google Analytics Account ID (if linking analytics with AdSense, i.e. `UA-#######-#`).

--- a/lib/module.js
+++ b/lib/module.js
@@ -5,6 +5,7 @@ const Defaults = {
   tag: 'adsbygoogle',
   id: null,
   pageLevelAds: false,
+  preventTopAnchorAds: false,
   includeQuery: false,
   analyticsUacct: '',
   analyticsDomainName: '',
@@ -23,6 +24,7 @@ module.exports = function nuxtAdSense (moduleOptions = {}) {
   // Normalize options
   options.test = Boolean(options.test)
   options.pageLevelAds = Boolean(options.pageLevelAds)
+  options.preventTopAnchorAds = Boolean(options.preventTopAnchorAds)
   options.includeQuery = String(Boolean(options.includeQuery))
   options.analyticsUacct = options.analyticsUacct || ''
   options.analyticsDomainName = options.analyticsDomainName || ''
@@ -69,6 +71,7 @@ module.exports = function nuxtAdSense (moduleOptions = {}) {
       (adsbygoogle = window.adsbygoogle || []).push({
         google_ad_client: "${options.id}",
         enable_page_level_ads: ${options.pageLevelAds ? 'true' : 'false'}
+        ${options.pageLevelAds && options.preventTopAnchorAds ? ', overlays: {bottom: true}' : ''}
       });
   `})
 


### PR DESCRIPTION
Anchor ads on the top of the screen can be very annoying for the user if the web app has a fixed top bar. Google allows forcing the position of anchor ads to the bottom of the screen:

https://support.google.com/adsense/answer/7478225

I've added this option as `preventTopAnchorAds` (I haven't updated the docs).

Thanks for this great module!