### PR TITLE
Add fullWidthResponsive prop

### DIFF
--- a/lib/plugin.template.js
+++ b/lib/plugin.template.js
@@ -19,7 +19,8 @@ const adsbygoogle = {
           'data-analytics-uacct': this.analyticsUacct ? this.analyticsUacct : null,
           'data-analytics-domain-name': this.analyticsDomainName ? this.analyticsDomainName : null,
           'data-adtest': <%= options.test ? '\'on\'' : 'null' %>,
-          'data-adsbygoogle-status': this.show ? null : ''
+          'data-adsbygoogle-status': this.show ? null : '',
+          ...(this.fullWidthResponsive !== '' && {'data-full-width-responsive': this.fullWidthResponsive})
         },
         domProps: {
           innerHTML: this.show ? '' : ' '
@@ -68,6 +69,10 @@ const adsbygoogle = {
     includeQuery: {
       type: Boolean,
       default: <%= options.includeQuery %>
+    },
+    fullWidthResponsive: {
+      type: String,
+      default: ''
     }
   },
   data () {


### PR DESCRIPTION
There's currently no way to set the `data-full-width-responsive` attribute on the `<ins` ad tag that this module generates. This is important for people who want to use Full Width Responsive ads as it affects the revenue generation significantly.

As quoted [here](https://support.google.com/adsense/answer/9183460?hl=en-GB), "Even when the data-full-width-responsive parameter isn't present in your ad code, your responsive ad unit will still expand to the full width of the user's screen on mobile devices in some instances. Although it won't do so as frequently as when the parameter is present and set to 'true'."

Therefore it's important to have the option to 
1) Not specify the parameter at all 
2) Set it 'true'
3) Set it 'false'

This PR just adds a String prop for this parameter.