### PR TITLE
fix: use `hid` to prevent duplicate scripting

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -65,8 +65,8 @@ module.exports = function nuxtAdSense (moduleOptions = {}) {
   })
 
   // Unfortunately these lines are needed to prevent vue-meta from esacping quotes in the init script
-  this.options.head.__dangerouslyDisableSanitizers = this.options.head.__dangerouslyDisableSanitizers || []
-  this.options.head.__dangerouslyDisableSanitizers.push('script')
+  this.options.head.__dangerouslyDisableSanitizersByTagID = this.options.head.__dangerouslyDisableSanitizersByTagID || {}
+  this.options.head.__dangerouslyDisableSanitizersByTagID.adsbygoogle = ['innerHTML']
 
   const adsenseScript = `{
     google_ad_client: "${options.id}",
@@ -76,11 +76,13 @@ module.exports = function nuxtAdSense (moduleOptions = {}) {
   // Initialize Adsense with ad client id
   if (!options.onPageLoad) {
     this.options.head.script.push({
+      hid: 'adsbygoogle',
       innerHTML: `
       (window.adsbygoogle = window.adsbygoogle || []).push(${adsenseScript});`
     })
   } else {
     this.options.head.script.push({
+      hid: 'adsbygoogle',
       innerHTML: `
       (window.adsbygoogle = window.adsbygoogle || []).onload = function () {
         [].forEach.call(document.getElementsByClassName('adsbygoogle'), function () {


### PR DESCRIPTION
Add unique `hid` property to prevent duplicating script on client side

fix #94