### PR TITLE
fix: ensure script calls once

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -60,6 +60,7 @@ module.exports = function nuxtAdSense (moduleOptions = {}) {
 
   // Add the async Google AdSense script to head
   this.options.head.script.push({
+    hid: 'adsbygoogle-script',
     async: true,
     src: AdSenseURL
   })
@@ -77,18 +78,18 @@ module.exports = function nuxtAdSense (moduleOptions = {}) {
   if (!options.onPageLoad) {
     this.options.head.script.push({
       hid: 'adsbygoogle',
-      innerHTML: `
-      (window.adsbygoogle = window.adsbygoogle || []).push(${adsenseScript});`
+      innerHTML: ensureScriptExecuteOnce(
+        `(window.adsbygoogle = window.adsbygoogle || []).push(${adsenseScript});`
+      )
     })
   } else {
     this.options.head.script.push({
       hid: 'adsbygoogle',
-      innerHTML: `
-      (window.adsbygoogle = window.adsbygoogle || []).onload = function () {
-        [].forEach.call(document.getElementsByClassName('adsbygoogle'), function () {
-            adsbygoogle.push(${adsenseScript});
-        })
-      }`
+      innerHTML: ensureScriptExecuteOnce(
+        `(window.adsbygoogle = window.adsbygoogle || []).onload = function () {
+          [].forEach.call(document.getElementsByClassName('adsbygoogle'), function () { adsbygoogle.push(${adsenseScript}); })
+        };`
+      )
     })
   }
 
@@ -100,6 +101,10 @@ module.exports = function nuxtAdSense (moduleOptions = {}) {
       content: 'noindex,noarchive,nofollow'
     })
   }
+}
+
+function ensureScriptExecuteOnce (script) {
+  return `if (!window.__abg_called){ ${script} window.__abg_called = true;}`
 }
 
 module.exports.meta = require('./../package.json')


### PR DESCRIPTION
On the server rendered pages google adsense script is present in the `head`. But after in the client side hydration the script does remove and a new script injects inside the `head` element.  Eventually Google adsense initialize twice and cause these two possible errors
```
- "adsbygoogle.push() error: Only one 'enable_page_level_ads' allowed per page."

- "adsbygoogle.push() error: All ins elements in the … with class=adsbygoogle already have ads in them."
```

With this PR, modules insures that initializer script will run once to prevent these issues.

fix #94