### PR TITLE
feat: Pause ads on start

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -10,7 +10,8 @@ const Defaults = {
   analyticsDomainName: '',
   overlayBottom: false,
   test: false,
-  onPageLoad: false
+  onPageLoad: false,
+  pauseOnLoad: false
 }
 
 // Default client ID for testing
@@ -30,6 +31,7 @@ module.exports = function nuxtAdSense (moduleOptions = {}) {
   options.analyticsDomainName = options.analyticsDomainName || ''
   options.overlayBottom = Boolean(options.overlayBottom)
   options.onPageLoad = Boolean(options.onPageLoad)
+  options.pauseOnLoad = Boolean(options.pauseOnLoad)
 
   if (this.options.dev && process.env.NODE_ENV !== 'production') {
     // If in DEV mode, place ads in 'test' state automatically
@@ -79,7 +81,8 @@ module.exports = function nuxtAdSense (moduleOptions = {}) {
     this.options.head.script.push({
       hid: 'adsbygoogle',
       innerHTML: ensureScriptExecuteOnce(
-        `(window.adsbygoogle = window.adsbygoogle || []).push(${adsenseScript});`
+        `(adsbygoogle=window.adsbygoogle||[]).pauseAdRequests=${options.pauseOnLoad ? '1' : '0'};
+         (window.adsbygoogle = window.adsbygoogle || []).push(${adsenseScript});`
       )
     })
   } else {
@@ -87,6 +90,7 @@ module.exports = function nuxtAdSense (moduleOptions = {}) {
       hid: 'adsbygoogle',
       innerHTML: ensureScriptExecuteOnce(
         `(window.adsbygoogle = window.adsbygoogle || []).onload = function () {
+          (adsbygoogle=window.adsbygoogle||[]).pauseAdRequests=${options.pauseOnLoad ? '1' : '0'};
           [].forEach.call(document.getElementsByClassName('adsbygoogle'), function () { adsbygoogle.push(${adsenseScript}); })
         };`
       )


### PR DESCRIPTION
Hello. 
Made some changes. Added Bollean pauseOnLoad option.
It pause the ads on page load for getting user consent of personal ads.

I use nuxt-cookie-control for solving GDPR issues. 
So after cookie agreed simply 

(adsbygoogle=window.adsbygoogle||[]).requestNonPersonalizedAds=1;  // or 0 if denied 
and 
(adsbygoogle=window.adsbygoogle||[]).pauseAdRequests=0

I think that option should be useful for other cookie consent modules