### PR TITLE
Allow config options via `publicRuntimeConfig`

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -20,7 +20,10 @@ const TestID = 'ca-google'
 const AdSenseURL = '//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js'
 
 module.exports = function nuxtAdSense (moduleOptions = {}) {
-  const options = Object.assign({}, Defaults, this.options['google-adsense'] || moduleOptions)
+  const runtimeConfig = this.options.publicRuntimeConfig['google-adsense'] || {}
+  const buildConfig = this.options['google-adsense'] || moduleOptions
+
+  const options = Object.assign({}, Defaults, { ...buildConfig, ...runtimeConfig })
 
   // Normalize options
   options.test = Boolean(options.test)


### PR DESCRIPTION
When deploying an application over the container, it is necessary to config the options via `publicRuntimeConfig`.