### PR TITLE
feat: ads personalization settings `pauseOnLoad`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ added to the `<head>` section of your pages.
 | `analyticsDomainName` | String | Google Analytics Account Domain (if linking analytics with AdSense, i.e. `example.com`).
 | `overlayBottom` | Boolean | Enable Adsense Anchor Ads to show at bottom. Default is `false`. Refer to the AdSense docs for details.
 | `onPageLoad` | Boolean | Loads Adsense script after page loade. Default is `false`.
+| `pauseOnLoad` | Boolean | Pauses ad requests to obtain user consent to use cookies or other local storage in accordance with the GDPR. Refer to the AdSense docs for details. `false`.
 | `test` | Boolean | Force AdSense into _test_ mode (see below).
 
 ### Test mode

--- a/lib/module.js
+++ b/lib/module.js
@@ -10,7 +10,8 @@ const Defaults = {
   analyticsDomainName: '',
   overlayBottom: false,
   test: false,
-  onPageLoad: false
+  onPageLoad: false,
+  pauseOnLoad: false
 }
 
 // Default client ID for testing
@@ -30,6 +31,7 @@ module.exports = function nuxtAdSense (moduleOptions = {}) {
   options.analyticsDomainName = options.analyticsDomainName || ''
   options.overlayBottom = Boolean(options.overlayBottom)
   options.onPageLoad = Boolean(options.onPageLoad)
+  options.pauseOnLoad = Boolean(options.pauseOnLoad)
 
   if (this.options.dev && process.env.NODE_ENV !== 'production') {
     // If in DEV mode, place ads in 'test' state automatically
@@ -79,7 +81,8 @@ module.exports = function nuxtAdSense (moduleOptions = {}) {
     this.options.head.script.push({
       hid: 'adsbygoogle',
       innerHTML: ensureScriptExecuteOnce(
-        `(window.adsbygoogle = window.adsbygoogle || []).push(${adsenseScript});`
+        `(adsbygoogle=window.adsbygoogle||[]).pauseAdRequests=${options.pauseOnLoad ? '1' : '0'};
+         (window.adsbygoogle = window.adsbygoogle || []).push(${adsenseScript});`
       )
     })
   } else {
@@ -87,6 +90,7 @@ module.exports = function nuxtAdSense (moduleOptions = {}) {
       hid: 'adsbygoogle',
       innerHTML: ensureScriptExecuteOnce(
         `(window.adsbygoogle = window.adsbygoogle || []).onload = function () {
+          (adsbygoogle=window.adsbygoogle||[]).pauseAdRequests=${options.pauseOnLoad ? '1' : '0'};
           [].forEach.call(document.getElementsByClassName('adsbygoogle'), function () { adsbygoogle.push(${adsenseScript}); })
         };`
       )


### PR DESCRIPTION
Added a new feature 'pauseOnLoad'.
When enabled, it pauses ad requests to obtain user consent to use cookies or other local storage in accordance with the GDPR. 
After getting user consent just can call `(adsbygoogle=window.adsbygoogle||[]).pauseAdRequests=0` to resume sending ad requests. Without making this call, no ads will be shown.
You can also use the feature for running personalized ads after obtaining user consent if needed.


[Refer to the AdSense docs for details.](https://support.google.com/adsense/answer/9042142)